### PR TITLE
gamecube-tools: added new package

### DIFF
--- a/gamecube-tools/all/cmake/gamecube-tools.cmake
+++ b/gamecube-tools/all/cmake/gamecube-tools.cmake
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.13)
+include_guard(GLOBAL)
+
+find_program(ELF2DOL_EXE NAMES elf2dol)
+find_program(GCDSPTOOL_EXE NAMES gcdsptool)
+find_program(GXTEXCONV_EXE NAMES gxtexconv)
+
+# Platform-specific helper utilities
+function(__dkp_target_derive_name outvar target suffix)
+	get_target_property(dir ${target} BINARY_DIR)
+	get_target_property(outname ${target} OUTPUT_NAME)
+	if(NOT outname)
+		set(outname "${target}")
+	endif()
+
+	set(${outvar} "${dir}/${outname}${suffix}" PARENT_SCOPE)
+endfunction()
+
+function(__dkp_set_target_file target)
+	if (NOT ${ARGC} GREATER 1)
+		message(FATAL_ERROR "dkp_set_target_file: must provide at least one input file")
+	endif()
+
+	set_target_properties(${target} PROPERTIES DKP_FILE "${ARGN}")
+endfunction()
+
+function(ogc_create_dol target)
+    if (NOT ELF2DOL_EXE)
+        message(FATAL_ERROR "Could not find elf2dol: try installing gamecube-tools")
+    endif()
+
+    __dkp_target_derive_name(DOL_OUTPUT ${target} ".dol")
+    add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND "${ELF2DOL_EXE}" "$<TARGET_FILE:${target}>" "${DOL_OUTPUT}"
+        BYPRODUCTS "${DOL_OUTPUT}"
+        COMMENT "Converting ${target} to .dol format"
+        VERBATIM
+    )
+    __dkp_set_target_file(${target} "${DOL_OUTPUT}")
+endfunction()

--- a/gamecube-tools/all/conandata.yml
+++ b/gamecube-tools/all/conandata.yml
@@ -1,0 +1,9 @@
+sources:
+  "1.0.6":
+    url: "https://github.com/devkitPro/gamecube-tools/archive/refs/tags/v1.0.6.tar.gz"
+    sha256: "0366e8b9b91025a0cf0aafd5c4b07a70ade54e3f04cf03ce93461f4a47b8ee9c"
+patches:
+  "1.0.6":
+    - patch_file: "patches/0001-elf2d-should-return-success-when-h-option.patch"
+      patch_description: "elf2dol should return success when -h"
+      patch_type: "bugfix"

--- a/gamecube-tools/all/conanfile.py
+++ b/gamecube-tools/all/conanfile.py
@@ -1,0 +1,63 @@
+import os
+from conan import ConanFile
+from conan.tools.files import copy
+from conan.tools.files import get, export_conandata_patches, apply_conandata_patches, copy
+from conan.tools.gnu import Autotools
+from conan.tools.layout import basic_layout
+
+
+required_conan_version = ">=2"
+
+class GameCubeToolsConan(ConanFile):
+    name = "gamecube-tools"
+    description = "Tools for gamecube/wii projects"
+    url = "https://github.com/devkitPro/gamecube-tools"
+    homepage = "https://github.com/devkitPro/gamecube-tools"
+    topics = ("nintendo", "wii", "gamecube")
+    settings = "os", "arch", "compiler", "build_type"
+    license = "GPL 2"
+
+    generators = "AutotoolsToolchain", "AutotoolsDeps"
+
+    def build_requirements(self):
+        self.tool_requires("pkgconf/2.2.0")
+        self.tool_requires("automake/1.16.5")
+        self.tool_requires("libtool/2.4.7")
+
+    def requirements(self):
+        self.requires("freeimage/3.18.0")
+
+    def layout(self):
+        basic_layout(self)
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+
+    def build(self):
+        apply_conandata_patches(self)
+        at = Autotools(self)
+        at.autoreconf()
+        at.configure()
+        at.make()
+
+    def package(self):
+        at = Autotools(self)
+        at.install()
+        copy(self, pattern="*.cmake", src=self.source_folder, dst=self.package_folder)
+        copy(self, pattern="*", src=os.path.join(self.source_folder, "LICENSE"), dst=self.package_folder) 
+
+    def package_id(self):
+        del self.info.settings.build_type
+        del self.info.settings.compiler
+
+    def package_info(self):
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+
+        cmake_user_toolchain = os.path.join(self.package_folder, "cmake", "gamecube-tools.cmake")
+        self.conf_info.append("tools.cmake.cmaketoolchain:user_toolchain", cmake_user_toolchain)
+

--- a/gamecube-tools/all/patches/0001-elf2d-should-return-success-when-h-option.patch
+++ b/gamecube-tools/all/patches/0001-elf2d-should-return-success-when-h-option.patch
@@ -1,0 +1,25 @@
+From 598d1d4264c1f4cf9ea02ccc621a1d5561ae53a2 Mon Sep 17 00:00:00 2001
+From: Elvis Dukaj <elvis.dukaj@gmail.com>
+Date: Tue, 21 Jan 2025 11:27:41 +0100
+Subject: [PATCH] elf2d should return success when -h option
+
+---
+ elftool/elf2dol.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/elftool/elf2dol.c b/elftool/elf2dol.c
+index c4d2942..fbe4a1a 100644
+--- a/elftool/elf2dol.c
++++ b/elftool/elf2dol.c
+@@ -435,7 +435,7 @@ int main(int argc, char **argv)
+ 	while(argc && *arg[0] == '-') {
+ 		if(!strcmp(*arg, "-h")) {
+ 			usage(argv[0]);
+-			return 1;
++			return 0;
+ 		} else if(!strcmp(*arg, "-v")) {
+ 			verbosity++;
+ 		} else if(!strcmp(*arg, "--")) {
+-- 
+2.47.1
+

--- a/gamecube-tools/all/test_package/CMakeLists.txt
+++ b/gamecube-tools/all/test_package/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.1)
+project(test_package)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+
+ogc_create_dol(${PROJECT_NAME})

--- a/gamecube-tools/all/test_package/conanfile.py
+++ b/gamecube-tools/all/test_package/conanfile.py
@@ -1,0 +1,33 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.layout import basic_layout
+from conan.tools.scm import Version
+from conan.tools.build import can_run
+
+
+class TestPackgeConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "VirtualBuildEnv"
+    test_type = "explicit"
+
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        valid_os = ["NintendtoWii", "NintendoGameCube"]
+        if self.settings.get_safe("os") in valid_os:
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run("gcdsptool -h")
+            self.run("elf2dol -h")
+            self.run("gxtexconv -h")
+

--- a/gamecube-tools/all/test_package/test_package.cpp
+++ b/gamecube-tools/all/test_package/test_package.cpp
@@ -1,0 +1,8 @@
+#include <cstdlib>
+#include <iostream>
+
+int main()
+{
+    std::cout << "conan-center-index\n";
+    return EXIT_SUCCESS;
+}

--- a/gamecube-tools/config.yml
+++ b/gamecube-tools/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "1.0.6:
+    folder: "all"


### PR DESCRIPTION
Adding gamecube-tools. The goal is to remove unrelated tools from the `devkitppc` package of tooling. 